### PR TITLE
Add overflow to code block in evaluation page

### DIFF
--- a/app/routes/evaluation.$taskId.tsx
+++ b/app/routes/evaluation.$taskId.tsx
@@ -13,7 +13,7 @@ export default function Evaluation() {
   return (
     <div className="flex flex-col justify-center items-center mt-2 space-y-3">
       <h1 className="text-3xl font-semibold p-5">Evaluating {task.title}</h1>
-      <pre className="bg-gray-900 text-gray-100 p-4 rounded-lg overflow-x-auto text-sm font-mono w-3/4">
+      <pre className="bg-gray-900 text-gray-100 p-4 rounded-lg overflow-x-auto overflow-y-auto text-sm font-mono w-3/4 max-h-48">
         <code>{task.solution}</code>
       </pre>
       <EvaluationChat


### PR DESCRIPTION
Code block would dissapear when the code was big enough. Fix the height and add overflow. 