### PR TITLE
Add control group option that disables evaluation

### DIFF
--- a/app/components/custom/python-code-runner.tsx
+++ b/app/components/custom/python-code-runner.tsx
@@ -11,9 +11,14 @@ import "prismjs/themes/prism.css";
 interface PythonCodeRunnerProps {
   solution: string;
   test_code: string;
+  is_control_group: boolean;
 }
 
-function PythonCodeRunner({ solution, test_code }: PythonCodeRunnerProps) {
+function PythonCodeRunner({
+  solution,
+  test_code,
+  is_control_group,
+}: PythonCodeRunnerProps) {
   const [pyodide, setPyodide] = useState<PyodideInterface | null>(null);
   const [output, setOutput] = useState<string | null>(null);
   const [codeInput, setCodeInput] = useState<string>(solution);
@@ -127,13 +132,15 @@ function PythonCodeRunner({ solution, test_code }: PythonCodeRunnerProps) {
               >
                 Test
               </Button>
-              <Button
-                name="action"
-                value="evaluate"
-                // disabled={!evaluationAllowed}
-              >
-                Evaluate
-              </Button>
+              {!is_control_group && (
+                <Button
+                  name="action"
+                  value="evaluate"
+                  //disabled={!evaluationAllowed}
+                >
+                  Evaluate
+                </Button>
+              )}
             </div>
           </div>
           <div className="bg-gray-100 p-4 rounded-md w-full">

--- a/app/routes/assignment.$assignmentId.task.$taskId.tsx
+++ b/app/routes/assignment.$assignmentId.task.$taskId.tsx
@@ -10,7 +10,7 @@ export const loader: LoaderFunction = taskLoader;
 export const action: ActionFunction = taskAction;
 
 export default function Task() {
-  const { task } = useLoaderData<typeof loader>();
+  const { task, assignment } = useLoaderData<typeof loader>();
 
   return (
     <>
@@ -21,6 +21,7 @@ export default function Task() {
       <PythonCodeRunner
         solution={task.solution ?? ""}
         test_code={task.test_code}
+        is_control_group={assignment.is_control_group}
       />
       <ChatButton taskDescription={task.description} />
     </>

--- a/app/routes/edit-assignment.$assignmentId.tsx
+++ b/app/routes/edit-assignment.$assignmentId.tsx
@@ -79,6 +79,14 @@ const EditAssignment = () => {
               defaultValue={assignment?.description || ""}
             />
           </div>
+          <div className="flex space-x-2">
+            <p className="text-gray-500 text-sm">Control group</p>
+            <input
+              type="checkbox"
+              name="isControlGroup"
+              defaultChecked={assignment?.is_control_group}
+            />
+          </div>
           <div className="space-x-2">
             <Button type="submit" name="action" value="editAssignment">
               Update assignment

--- a/app/services/edit-assignment-action.ts
+++ b/app/services/edit-assignment-action.ts
@@ -1,5 +1,4 @@
 import { ActionFunction, redirect } from "@remix-run/node";
-import { i } from "node_modules/vite/dist/node/types.d-aGj9QkWt";
 import { supabaseClient as supabase } from "~/auth/supabase.server";
 
 const editAssignment = async (assignmentId: number, formData: FormData) => {

--- a/app/services/edit-assignment-action.ts
+++ b/app/services/edit-assignment-action.ts
@@ -1,12 +1,18 @@
 import { ActionFunction, redirect } from "@remix-run/node";
+import { i } from "node_modules/vite/dist/node/types.d-aGj9QkWt";
 import { supabaseClient as supabase } from "~/auth/supabase.server";
 
 const editAssignment = async (assignmentId: number, formData: FormData) => {
   const assignmentTitle = formData.get("assignmentTitle") as string;
   const assignmentDescription = formData.get("assignmentDescription") as string;
+  const isControlGroup = formData.get("isControlGroup") === "on";
   const { error } = await supabase
     .from("assignments")
-    .update({ title: assignmentTitle, description: assignmentDescription })
+    .update({
+      title: assignmentTitle,
+      description: assignmentDescription,
+      is_control_group: isControlGroup,
+    })
     .eq("id", assignmentId);
   if (error) {
     throw new Error(`Error editing assignment: ${error.message}`);

--- a/app/services/task-loader.ts
+++ b/app/services/task-loader.ts
@@ -1,7 +1,7 @@
 import { LoaderFunction } from "@remix-run/node";
 import OpenAI from "openai";
 import { supabaseClient as supabase } from "~/auth/supabase.server";
-import { Task } from "~/types/types";
+import { Assignment, Task } from "~/types/types";
 
 export const fetchThread = async (taskId: number) => {
   const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
@@ -45,6 +45,12 @@ export const taskLoader: LoaderFunction = async (args) => {
     fetchThread(taskId),
   ]);
 
+  const assignment = await supabase
+    .from("assignments")
+    .select("*")
+    .eq("id", taskResult.data.assignment_id)
+    .single();
+
   const threadData = thread ? await thread.json() : null;
 
   if (taskResult.error) {
@@ -54,5 +60,6 @@ export const taskLoader: LoaderFunction = async (args) => {
   return {
     task: taskResult.data as Task,
     thread: threadData ?? [],
+    assignment: assignment.data as Assignment,
   };
 };

--- a/app/types/types.ts
+++ b/app/types/types.ts
@@ -6,6 +6,7 @@ export type Assignment = {
   total_tasks: number;
   approved_tasks: number;
   all_tasks_approved: boolean;
+  is_control_group: boolean;
 };
 
 export type Task = {


### PR DESCRIPTION
Add control group option to assignments, turning it on will hide the evaluation button for all tasks belonging the assignment.